### PR TITLE
correct rights on build dir

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -34,6 +34,9 @@ pushd "$install_dir"
  	ynh_hide_warnings ynh_exec_as_app npm run build
 popd
 
+# Set correct rights on build dir
+chgrp -R www-data $install_dir/dist/
+
 #=================================================
 # END OF SCRIPT
 #=================================================


### PR DESCRIPTION
It seems the manifest set the rights before the package is built, thus /var/www/prose/ is correct, but /var/www/prose/dist/ is not.